### PR TITLE
Potential fix for code scanning alert no. 114: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -17,6 +17,9 @@
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
 
 name: "Microsoft Defender For Devops"
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Deploy-to-Azure/security/code-scanning/114](https://github.com/Git-Hub-Chris/Deploy-to-Azure/security/code-scanning/114)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily reads repository contents and uploads SARIF files to the Security tab. Therefore, we will set `contents: read` and `security-events: write` permissions. These permissions are sufficient for the workflow's operations and adhere to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
