### PR TITLE
Potential fix for code scanning alert no. 116: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -20,6 +20,9 @@
 #    action executes, check the 'Security' tab for results
 
 name: Appknox
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Deploy-to-Azure/security/code-scanning/116](https://github.com/Git-Hub-Chris/Deploy-to-Azure/security/code-scanning/116)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- The `contents: read` permission is needed to check out the repository code.
- The `security-events: write` permission is required to upload the SARIF file to GitHub Advanced Security (GHAS).

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
